### PR TITLE
fix: use hyphenated distribution name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "pytask_r"
+name = "pytask-r"
 description = "Run R scripts with pytask."
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
## Summary

- Change the project distribution name from `pytask_r` to `pytask-r` in `pyproject.toml`.
- Keep the import package and pytask plugin entry point as `pytask_r`.

## Why

PyPI displays the distribution name from package metadata in the install command. Python packaging normalizes underscores and hyphens to the same project key, but using the hyphenated distribution name keeps PyPI aligned with the README, repository name, and installation instructions.

## Validation

- rebased onto fetched `origin/main`
- `uv build`
- inspected generated wheel metadata: `Name: pytask-r`
- `uv run --group test pytest` passed with 12 passed, 27 skipped
